### PR TITLE
Remove property from word class

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -81,7 +81,6 @@ body,
 .word {
   margin-bottom: 20px;
   display: grid;
-  justify-items: auto;
   justify-content: center;
   grid-template-columns: repeat(auto-fit, 50px);
 }


### PR DESCRIPTION
Associated Issue: #35 

### Summary of Changes
We need to remove `justify-items: auto` because has an invalid value.

