### PR TITLE
Update .gitignore to include package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 .DS_Store
 dist
 coverage
+package-lock.json


### PR DESCRIPTION
This locks the dependencies used to let the project be more stable-friendly. This also prevents future PR to update the dependencies as a side-effect. I personally suffered from this in my previous PR.

But what do you think about this?
