### PR TITLE
Shuffle rebuses to randomize the game a bit

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -82,7 +82,7 @@ const rebuses = [
 ];
 
 export function getRebuses() {
-  return rebuses.map((rebus, id) => ({
+  return shuffle(rebuses).map((rebus, id) => ({
     id,
     ...rebus,
     input: [...Array(rebus.words.join('').length)],
@@ -92,4 +92,8 @@ export function getRebuses() {
 
 export function getRebus(id) {
   return getRebuses().find(rebus => rebus.id === id);
+}
+
+export function shuffle(collection) {
+  return collection.sort(() => 0.5 - Math.random());
 }

--- a/tests/components.spec.js
+++ b/tests/components.spec.js
@@ -5,6 +5,10 @@ jest.mock('../src/js/store', () => ({
   connect: arg => arg
 }));
 
+jest.mock('../src/js/rebuses', () => ({
+  shuffle: collection => collection
+}));
+
 const mockState = {
   current: 0,
   animation: 'none',


### PR DESCRIPTION
This allows to shuffle the rebuses collection so that we don't get the same rebus order every time we refresh.

To maintain compatability with the current tests, the `shuffle` function was mocked to return the same collection.
