### PR TITLE
Created eventListener for arrow keyup

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -3,6 +3,18 @@ import { App, Logo, GithubCorner, ChangeButton, Rebus } from './components';
 import { actions } from './store';
 import '../css/main.css';
 
+function registerListeners() {
+  document.addEventListener('keyup', event => {
+    const key = event.key || event.keyCode; // For older browser support
+    if (key === 'ArrowRight' || key === 39) {
+      actions.next();
+    }
+    if (key === 'ArrowLeft' || key === 37) {
+      actions.prev();
+    }
+  });
+}
+
 export function init() {
   return render(
     App(
@@ -30,4 +42,5 @@ export function init() {
 
 if (!global || !global.isTestRun) {
   init();
+  registerListeners();
 }


### PR DESCRIPTION
Associated Issue: #69

### Summary of Changes

- Created function `registerListeners` which adds listener on `keyup`
- `registerListeners` will look for `event.key` first, with `event.keyCode` as fallback in case of (somehow) a much older browser.
- `registerListeners` will call `actions.next()` or `actions.prev()` depending on the key
- `registerListeners` is called after `init()`
