### PR TITLE
Jump to prev input field when backspace is pressed

### DIFF
--- a/src/js/components.js
+++ b/src/js/components.js
@@ -54,9 +54,21 @@ export function Word(props, ...children) {
             charInput(input, props.wordIndex, charIndex);
 
             if (/[a-zA-Z]/.test(input)) {
-              const nextChildren = this.children[charIndex].$element.nextSibling;
-              if (nextChildren != null) {
-                nextChildren.focus();
+              const nextChild = e.target.nextElementSibling;
+              if (nextChild !== null) {
+                nextChild.focus();
+              }
+            }
+          },
+          onKeydown: e => {
+            const key = e.key || e.keyCode;
+
+            if (key === 'Backspace' || key === 8) {
+              const input = e.target.value;
+              const prevChild = e.target.previousElementSibling;
+              if (prevChild !== null && input === '') {
+                prevChild.focus();
+                e.preventDefault();
               }
             }
           }

--- a/tests/components.spec.js
+++ b/tests/components.spec.js
@@ -64,7 +64,7 @@ describe('Tests for components', () => {
       inputElement.dispatchEvent(new Event('input'));
       expect(onInput).toHaveBeenCalledWith('T', 0, 0);
     });
-    it('jumps to next simbling when a letter is pressed', () => {
+    it('jumps to next input field when a letter is pressed', () => {
       const onInput = jest.fn();
       const props = { ...mockState, word: 'one', wordIndex: 0, charInput: onInput };
       const root = document.createElement('div');
@@ -75,7 +75,7 @@ describe('Tests for components', () => {
       inputs[0].dispatchEvent(new Event('input'));
       expect(inputs[1] === document.activeElement).toEqual(true);
     });
-    it('it remains on the same node when a character that is not a letter is pressed', () => {
+    it('remains on the same input field when a character that is not a letter is pressed', () => {
       const onInput = jest.fn();
       const props = { ...mockState, word: 'one', wordIndex: 0, charInput: onInput };
       const root = document.createElement('div');
@@ -85,6 +85,31 @@ describe('Tests for components', () => {
       inputs[0].value = '!';
       inputs[0].dispatchEvent(new Event('input'));
       expect(inputs[0] === document.activeElement).toEqual(true);
+    });
+    it('jumps to the previous input field when pressing backspace in empty field', () => {
+      const onInput = jest.fn();
+      const props = { ...mockState, word: 'one', wordIndex: 0, charInput: onInput };
+      const root = document.createElement('div');
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.key = 'Backspace';
+      inputs[1].focus();
+      inputs[1].dispatchEvent(mockEvent);
+      expect(inputs[0] === document.activeElement).toEqual(true);
+    });
+    it('remains on the same input field when pressing backspace in non empty field', () => {
+      const onInput = jest.fn();
+      const props = { ...mockState, word: 'one', wordIndex: 0, charInput: onInput };
+      const root = document.createElement('div');
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.key = 'Backspace';
+      inputs[1].focus();
+      inputs[1].value = 'T';
+      inputs[1].dispatchEvent(mockEvent);
+      expect(inputs[1] === document.activeElement).toEqual(true);
     });
   });
   describe('Char', () => {


### PR DESCRIPTION
Associated Issue: #67 

### Summary of Changes
- Adding onKeydown event listener in the Word component to handle backspace input
- Adding test cases
