### PR TITLE
Implemented saving and restoring of game state in localStorage

### DIFF
--- a/src/js/components.js
+++ b/src/js/components.js
@@ -67,6 +67,9 @@ export function Word(props, ...children) {
               const input = e.target.value;
               const prevChild = e.target.previousElementSibling;
               if (prevChild !== null && input === '') {
+                const prevChildInput = prevChild.value;
+                prevChild.value = '';
+                prevChild.value = prevChildInput;
                 prevChild.focus();
                 e.preventDefault();
               }

--- a/src/js/mini/localState.js
+++ b/src/js/mini/localState.js
@@ -1,0 +1,55 @@
+const GAME_STATE = 'gameState';
+
+const hasChangedInput = ({ input }) => input.filter(char => char).length;
+
+const inputToString = input => input.reduce((str, char) => (char ? str + char : str));
+
+const toLocalRebus = ({ id, input, isAnswered }) => ({
+  id,
+  input: inputToString(input),
+  isAnswered
+});
+
+const localStateFromGameState = ({ current = 0, updatedRebuses = [] }) => ({
+  current,
+  updatedRebuses: updatedRebuses.filter(hasChangedInput).map(toLocalRebus)
+});
+
+export const setLocalGameState = state =>
+  localStorage.setItem(GAME_STATE, JSON.stringify(localStateFromGameState(state)));
+
+export const initializeWithLocalState = initialState => {
+  const localState = localStorage.getItem(GAME_STATE);
+
+  if (!localState) {
+    setLocalGameState(initialState);
+    return initialState;
+  }
+
+  const { current, updatedRebuses: localUpdatedRebuses } = JSON.parse(localState);
+  const rebuses = initialState.rebuses.map(rebus => {
+    const localRebus = localUpdatedRebuses.find(({ id }) => id === rebus.id);
+
+    if (!localRebus) return rebus;
+
+    const { isAnswered } = localRebus;
+    const input = rebus.input.map((char, i) => localRebus.input.charAt(i) || char);
+
+    return {
+      ...rebus,
+      isAnswered,
+      input
+    };
+  });
+
+  return {
+    ...initialState,
+    current,
+    rebuses
+  };
+};
+
+export const localState = {
+  set: setLocalGameState,
+  initialize: initializeWithLocalState
+};

--- a/src/js/mini/store.js
+++ b/src/js/mini/store.js
@@ -1,7 +1,9 @@
+import { localState } from './localState';
+
 export function createStore(initialState, actions) {
   const store = {
     connectedComponents: [],
-    state: initialState
+    state: localState.initialize(initialState)
   };
   store.actions = new Proxy(actions, {
     get(target, key) {
@@ -9,6 +11,7 @@ export function createStore(initialState, actions) {
         const newState = await actions[key](store.state, ...args);
         store.state = Object.assign(store.state, newState);
         store.connectedComponents.forEach(c => c.update());
+        localState.set(store.state);
       };
     }
   });


### PR DESCRIPTION
Associated Issue: #93 

I implemented functionality for saving and restoring the game state. It hooks into the store to change any relevant changes to the local storage. When the app is loaded, the local state will be merged with the initial state passed to the store.

Unfortunately, the Word renderer in `src/js/components.js` needed a little hack for removing input with backspace to work.
