### PR TITLE
Adding componentDidRender lifecycle method

### DIFF
--- a/src/js/mini/component.js
+++ b/src/js/mini/component.js
@@ -1,10 +1,11 @@
 import { renderComponent } from './render';
 
-export function createComponent({ props = {}, children = [], render }) {
+export function createComponent({ props = {}, children = [], render, componentDidRender }) {
   const component = {
     props,
     children,
     render,
+    componentDidRender,
     update() {
       if (this.rendered !== this.render()) {
         renderComponent(this, this.$parent);

--- a/src/js/mini/render.js
+++ b/src/js/mini/render.js
@@ -29,6 +29,7 @@ export function renderComponent(component, $parent) {
   }
   if (component.$element) {
     component.$parent.replaceChild($element, component.$element);
+    callDidRender(component);
   }
   if (component.props.focus) {
     $element.focus();
@@ -38,7 +39,15 @@ export function renderComponent(component, $parent) {
   return $element;
 }
 
+export function callDidRender(component) {
+  if (component.componentDidRender) {
+    component.componentDidRender();
+  }
+  component.children.forEach(child => callDidRender(child));
+}
+
 export function render(component, root) {
   const element = renderComponent(component, root);
   root.appendChild(element);
+  callDidRender(component);
 }

--- a/tests/__snapshots__/app.spec.js.snap
+++ b/tests/__snapshots__/app.spec.js.snap
@@ -5,12 +5,14 @@ Object {
   "children": Array [
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {},
       "render": [Function],
       "update": [Function],
     },
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {
         "url": "https://github.com/ollelauribostrom/rebus",
       },
@@ -19,6 +21,7 @@ Object {
     },
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {
         "className": "change-button--prev",
         "onClick": [Function],
@@ -28,6 +31,7 @@ Object {
     },
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {
         "charInput": [Function],
       },
@@ -36,6 +40,7 @@ Object {
     },
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {
         "className": "change-button--next",
         "onClick": [Function],
@@ -44,6 +49,7 @@ Object {
       "update": [Function],
     },
   ],
+  "componentDidRender": undefined,
   "props": Object {},
   "render": [Function],
   "update": [Function],

--- a/tests/__snapshots__/components.spec.js.snap
+++ b/tests/__snapshots__/components.spec.js.snap
@@ -5,11 +5,13 @@ Object {
   "children": Array [
     Object {
       "children": Array [],
+      "componentDidRender": undefined,
       "props": Object {},
       "render": [Function],
       "update": [Function],
     },
   ],
+  "componentDidRender": undefined,
   "props": Object {},
   "render": [Function],
   "update": [Function],
@@ -27,6 +29,7 @@ exports[`Tests for components App renders correctly 2`] = `
 exports[`Tests for components ChangeButton renders correctly (with className prop) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "className": "test",
   },
@@ -57,6 +60,7 @@ exports[`Tests for components ChangeButton renders correctly (with className pro
 exports[`Tests for components ChangeButton renders correctly (without className prop) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {},
   "render": [Function],
   "update": [Function],
@@ -85,6 +89,7 @@ exports[`Tests for components ChangeButton renders correctly (without className 
 exports[`Tests for components Char renders correctly (with value and multiple words) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "none",
     "charIndex": 1,
@@ -132,6 +137,7 @@ exports[`Tests for components Char renders correctly (with value and multiple wo
 exports[`Tests for components Char renders correctly (with value and single word) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "none",
     "charIndex": 1,
@@ -179,6 +185,7 @@ exports[`Tests for components Char renders correctly (with value and single word
 exports[`Tests for components Char renders correctly (without value) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "none",
     "charIndex": 1,
@@ -226,6 +233,7 @@ exports[`Tests for components Char renders correctly (without value) 2`] = `
 exports[`Tests for components GithubCorner renders correctly 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "url": "test",
   },
@@ -251,6 +259,7 @@ exports[`Tests for components GithubCorner renders correctly 2`] = `
 exports[`Tests for components Logo renders correctly 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {},
   "render": [Function],
   "update": [Function],
@@ -276,6 +285,7 @@ exports[`Tests for components Logo renders correctly 2`] = `
 exports[`Tests for components Rebus renders correctly (when rebus is answered) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "none",
     "current": 0,
@@ -324,6 +334,7 @@ exports[`Tests for components Rebus renders correctly (when rebus is answered) 2
 exports[`Tests for components Rebus renders correctly (with animation class) 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "flip-vertical-right",
     "current": 0,
@@ -372,6 +383,7 @@ exports[`Tests for components Rebus renders correctly (with animation class) 2`]
 exports[`Tests for components Rebus renders correctly 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "animation": "none",
     "current": 0,
@@ -420,6 +432,7 @@ exports[`Tests for components Rebus renders correctly 2`] = `
 exports[`Tests for components Word renders correctly 1`] = `
 Object {
   "children": Array [],
+  "componentDidRender": undefined,
   "props": Object {
     "charInput": [MockFunction],
     "word": "one",

--- a/tests/mini.spec.js
+++ b/tests/mini.spec.js
@@ -5,6 +5,7 @@ const wait = duration => new Promise(resolve => setTimeout(resolve, duration));
 function Parent(...children) {
   return createComponent({
     children,
+    componentDidRender: jest.fn(),
     render() {
       return `
         <div class="parent">
@@ -14,9 +15,10 @@ function Parent(...children) {
   });
 }
 
-function Child(props) {
+function Child(props, componentDidRender) {
   return createComponent({
     props,
+    componentDidRender,
     render({ text }) {
       return `<span class="child">${text}</span>`;
     }
@@ -41,6 +43,19 @@ describe('Tests for mini framework', () => {
       render(Child({ onClick }), root);
       root.firstElementChild.click();
       expect(onClick).toHaveBeenCalled();
+    });
+    it('calls componentDidRender after the component has been rendered', () => {
+      const childOneDidRender = jest.fn();
+      const childTwoDidRender = jest.fn();
+      const root = document.createElement('div');
+      const parent = Parent(
+        Child({ text: 'Child1' }, childOneDidRender),
+        Child({ text: 'Child2' }, childTwoDidRender)
+      );
+      render(parent, root);
+      expect(parent.componentDidRender).toHaveBeenCalledTimes(1);
+      expect(childOneDidRender).toHaveBeenCalledTimes(1);
+      expect(childTwoDidRender).toHaveBeenCalledTimes(1);
     });
   });
   describe('store', () => {


### PR DESCRIPTION
(somewhat) Associated Issue: #131

### Summary of Changes
- Adding componentDidRender lifecycle method to the render framework

### Usage
The componentDidRender lifecycle method can be used as following
```js
export function MyComponent(props) {
  return createComponent({
    props,
    componentDidRender() {
      this.$element.focus();
    },
    render({ someProp }) {
      return `<span>${someProp}</span>`;
    }
  });
}
```