### PR TITLE
Fix path in rebus history update

### DIFF
--- a/src/js/components/rebus.js
+++ b/src/js/components/rebus.js
@@ -20,7 +20,8 @@ export function Rebus(props, ...children) {
         /* If history API isn't available, we shouldn't revert to the more widely available `window.location.href`, 
         as it incurs a new HTTP request and thus results in an infinite loop (and breaks SPAs). */
         if (window.history) {
-          window.history.pushState('', '', `/?rebus=${rebus.id}`);
+          // Adds 'rebus' query parameter to end of URL. Should be endpoint-agnostic.
+          window.history.pushState('', '', `?rebus=${rebus.id}`);
         }
         if (rebus.isAnswered) {
           this.$parent.querySelector('.change-button--next').focus();


### PR DESCRIPTION
Associated Issue: #172

Switching from the absolute path assignment `/?rebus=${rebus.id}` to the relative `?rebus=${rebus.id}` should fix the issue, as it should now simply append the query parameter instead of replacing the non-root end-point that we're serving from.

Tried serving from a non-root end-point using webpack and it seemed to work perfectly, but let me know if you run into any issues during actual deployment. 👍 