### PR TITLE
Add new rebus: keychain

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -739,7 +739,7 @@ const rebuses = [
   {
     symbols: ['🔑', '+', '⛓️'],
     words: ['keychain'],
-    hint: 'Holds on to one or more keys'
+    hint: 'Something that holds on to one or more keys'
   }
 ];
 

--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -735,6 +735,11 @@ const rebuses = [
     symbols: ['🌲', '+', 'T'],
     words: ['treaty'],
     hint: 'an agreement between countries'
+  },
+  {
+    symbols: ['🔑', '+', '⛓️'],
+    words: ['keychain'],
+    hint: 'Holds on to one or more keys'
   }
 ];
 


### PR DESCRIPTION
Associated Issue: #121 

### Summary of Changes

- Added new rebus with:
    - symbols: ['🔑', '+', '⛓️']
    - words: ['keychain']
    - hints: "Something that holds on to one or more keys"
