### PR TITLE
New feature - Auto-clear fields when typing.

### DIFF
--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -23,9 +23,9 @@ export function Word(props, ...children) {
             }
           },
           onKeydown: e => {
-            const key = e.key;
-            const keyCode = e.keyCode;
-            if (keyCode >= 65 && keyCode <= 90){
+            const { key } = e;
+            const { keyCode } = e;
+            if (keyCode >= 65 && keyCode <= 90) {
               e.target.value = '';
             }
             if (key === 'Enter' || keyCode === 13) {

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -23,11 +23,15 @@ export function Word(props, ...children) {
             }
           },
           onKeydown: e => {
-            const key = e.key || e.keyCode;
-            if (key === 'Enter' || key === 13) {
+            const key = e.key;
+            const keyCode = e.keyCode;
+            if (keyCode >= 65 && keyCode <= 90){
+              e.target.value = '';
+            }
+            if (key === 'Enter' || keyCode === 13) {
               actions.shake();
             }
-            if (key === 'Backspace' || key === 8) {
+            if (key === 'Backspace' || keyCode === 8) {
               const input = e.target.value;
               const prevChild = e.target.previousElementSibling;
               if (prevChild !== null && input === '') {

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -23,17 +23,16 @@ export function Word(props, ...children) {
             }
           },
           onKeydown: e => {
-            const { key } = e;
-            const { keyCode } = e;
+            const { key, keyCode, target } = e;
             if (keyCode >= 65 && keyCode <= 90) {
-              e.target.value = '';
+              target.value = '';
             }
             if (key === 'Enter' || keyCode === 13) {
               actions.shake();
             }
             if (key === 'Backspace' || keyCode === 8) {
-              const input = e.target.value;
-              const prevChild = e.target.previousElementSibling;
+              const input = target.value;
+              const prevChild = target.previousElementSibling;
               if (prevChild !== null && input === '') {
                 prevChild.focus();
                 e.preventDefault();

--- a/tests/components.spec.js
+++ b/tests/components.spec.js
@@ -123,6 +123,32 @@ describe('Tests for components', () => {
       inputs[1].dispatchEvent(mockEvent);
       expect(inputs[1] === document.activeElement).toEqual(true);
     });
+    it('clears field when user enters a valid letter character in non empty field', () => {
+      const onInput = jest.fn();
+      const props = { ...getMockState(), word: 'one', wordIndex: 0, charInput: onInput };
+      const root = document.createElement('div');
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.keyCode = '87';
+      inputs[1].focus();
+      inputs[1].value = 'T';
+      inputs[1].dispatchEvent(mockEvent);
+      expect(inputs[1].value === '').toEqual(true);
+    });
+    it('does not clear field if non letter character is entered', () => {
+      const onInput = jest.fn();
+      const props = { ...getMockState(), word: 'one', wordIndex: 0, charInput: onInput };
+      const root = document.createElement('div');
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.keyCode = '16';
+      inputs[1].focus();
+      inputs[1].value = 'T';
+      inputs[1].dispatchEvent(mockEvent);
+      expect(inputs[1].value === 'T').toEqual(true);
+    });
   });
   describe('Char', () => {
     it('renders correctly (without value)', () => {


### PR DESCRIPTION
### Summary of Changes

- Updated the onKeydown event handler in Word.js. 

Now, if a user types a valid letter into a character field, it will automatically be cleared out, instead of the user having to click backspace before typing. This is especially beneficial for correcting typos.

Note that I separated 'key' into two constants: key & keyCode. 
This is because I am validating the keyCode as opposed to the key to determine if a letter is being typed. Reason being that values like 'Tab', 'Shift' or 'F11' would be included in an `if (/[a-zA-Z]/.test(input))` clause, and we don't want fields being cleared out unless a user is typing a valid character into one. 