### PR TITLE
Deleted duplicates added and changed hints

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -266,7 +266,7 @@ const rebuses = [
   {
     symbols: ['🌧', '+', '🏹'],
     words: ['rainbow'],
-    hint: '🌈'
+    hint: 'You see this after it rains'
   },
   {
     symbols: ['❄️', '+', '⚾️'],
@@ -276,17 +276,12 @@ const rebuses = [
   {
     symbols: ['❄️', '+', 'man'],
     words: ['snowman'],
-    hint: '⛄'
+    hint: 'You make this when its snowing'
   },
   {
     symbols: ['🐏', '📃'],
     words: ['rampage'],
     hint: `The Hulk likes to go on a ____`
-  },
-  {
-    symbols: ['✝️', '+', '🏹'],
-    words: ['cross', 'bow'],
-    hint: 'A sophisticated version of the bow and arrow'
   },
   {
     symbols: ['🐈', '+', '🥊'],
@@ -356,7 +351,7 @@ const rebuses = [
   {
     symbols: ['🐱', '+', 'er', '+', '🗼'],
     words: ['caterpillar'],
-    hint: 'A tiny insect with many feet'
+    hint: 'It chews on leaves and then grows into something pretty.'
   },
   {
     symbols: ['🧢', '+', 'tain'],
@@ -381,7 +376,7 @@ const rebuses = [
   {
     symbols: ['🎼', '+', '🍴'],
     words: ['pitchfork'],
-    hint: `You will need one to chase down Frankenstein's monster`
+    hint: `Angry mobs are frequently seen with this`
   },
   {
     symbols: ['🌊', '+', '🐴'],
@@ -476,7 +471,7 @@ const rebuses = [
   {
     symbols: ['💥', '+', 'py'],
     words: ['Poppy'],
-    hint: `From Game of Thrones: 'Milk of the ____'`
+    hint: `They make opium from this`
   },
   {
     symbols: ['🍏', '+', '🥧'],
@@ -741,7 +736,7 @@ const rebuses = [
   {
     symbols: ['🔥', '+', '🤼', '+', 'er'],
     words: ['firefighter'],
-    hint: 'Someone trained to combat fires and rescue people trapped by fires'
+    hint: 'They show up when there is a fire'
   },
   {
     symbols: ['1', '+', 'ce', '+', 'n', '+', 'a', '+', '🔵', '+', '🌛'],
@@ -785,7 +780,8 @@ const rebuses = [
   },
   {
     symbols: ['✝', '+', '🏹'],
-    words: ['Crossbow']
+    words: ['Crossbow'],
+    hint: 'What an unskilled archer would use'
   },
   {
     symbols: ['D', '+', '💡'],
@@ -864,7 +860,8 @@ const rebuses = [
   },
   {
     symbols: ['🎁', '+', '🃏'],
-    words: ['gift', 'card']
+    words: ['gift', 'card'],
+    hint: 'You get one on your birthday'
   },
   {
     symbols: ['🏹', '+', '👔'],


### PR DESCRIPTION
Associated Issue: #180

Deleted copy of crossbow. Added and modified hints that made it too easy.

- Changed hint for rainbow which was 🌈 before
- Changed hint for snowman which was ⛄️  before
- Removed a copy of Crossbow
- Gave accurate hint for caterpillar, pitchfork, firefighter, poppy
- Added hints for giftcard and crossbow
