### PR TITLE
Add fast scroll

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,13 +12,25 @@ import { actions } from './store';
 import '../css/main.css';
 
 export function registerListeners() {
+  let modifier = false;
   document.addEventListener('keyup', event => {
     const key = event.key || event.keyCode; // For older browser support
     if (key === 'ArrowRight' || key === 39) {
-      actions.next();
+      if (!modifier) actions.next();
+      if (modifier) actions.next10();
     }
     if (key === 'ArrowLeft' || key === 37) {
-      actions.prev();
+      if (!modifier) actions.prev();
+      if (modifier) actions.prev10();
+    }
+    if (key === 'Shift' || key === 16) {
+      modifier = false;
+    }
+  });
+  document.addEventListener('keydown', event => {
+    const key = event.key || event.keyCode;
+    if (key === 'Shift' || key === 16) {
+      modifier = true;
     }
   });
 }

--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -889,7 +889,7 @@ const rebuses = [
     hint: ['An insect that makes a sweet treat.']
   },
   {
-    symbols: ['🖊', '+', 'a', '😎'],
+    symbols: ['🖊', '+', 'a', '+', '😎'],
     words: ['pinnacle'],
     hint: ['The very top']
   }

--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -887,6 +887,11 @@ const rebuses = [
     symbols: ['🍯', '+', '🐝'],
     words: ['honeybee'],
     hint: ['An insect that makes a sweet treat.']
+  },
+  {
+    symbols: ['🖊', '+', 'a', '😎'],
+    words: ['pinnacle'],
+    hint: ['The very top']
   }
 ];
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -13,6 +13,16 @@ export const actionsCreators = {
     animation: 'flip-vertical-left',
     incorrectAnswerCount: 0
   }),
+  next10: ({ current, rebuses }) => ({
+    current: current < rebuses.length - 10 ? current + 10 : 0,
+    animation: 'flip-vertical-right',
+    incorrectAnswerCount: 0
+  }),
+  prev10: ({ current, rebuses }) => ({
+    current: current > 0 ? current - 10 : rebuses.length - 10,
+    animation: 'flip-vertical-left',
+    incorrectAnswerCount: 0
+  }),
   setCurrent: ({ rebuses }, id) => {
     const index = rebuses.findIndex(rebus => rebus.id === id);
     if (index > 0) {


### PR DESCRIPTION
Associated Issue: NA

### Summary of Changes

- Added SHIFT + ARROW KEY scroll option to scroll by 10 cards (as opposed to one only via arrow keys)
- Changes to store with additional next10, prev10 methods for scrolling by 10 cards
- Changes to app to detect if shift is pressed with a modifier boolean on keyDown, and reverse the boolean on keyUp
