### PR TITLE
Backspace functionality improved

### DIFF
--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -39,15 +39,13 @@ export function Word(props, ...children) {
               const input = target.value;
               const prevChild = target.previousElementSibling;
               if (prevChild !== null && input === '') {
-
                 prevChild.focus();
                 e.preventDefault();
               }
               else if (target.parentElement && input === '') {
-                var previousSibling = target.parentElement.previousSibling;
-
+                const previousSibling = target.parentElement.previousSibling;
                 if (previousSibling) {
-                  var lastChildOfParent = previousSibling.lastElementChild;
+                  const lastChildOfParent = previousSibling.lastElementChild;
                   if (lastChildOfParent) {
                     lastChildOfParent.focus();
                     e.preventDefault();

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -41,7 +41,7 @@ export function Word(props, ...children) {
               if (prevChild !== null && input === '') {
                 prevChild.focus();
                 e.preventDefault();
-              }else if (target != null && target.parentElement && input === '') {
+              } else if (target != null && target.parentElement && input === '') {
                 const previousSibling = target.parentElement.previousSibling;
                 if (previousSibling !== null) {
                   const lastChildOfParent = previousSibling.lastElementChild;

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -39,8 +39,20 @@ export function Word(props, ...children) {
               const input = target.value;
               const prevChild = target.previousElementSibling;
               if (prevChild !== null && input === '') {
+
                 prevChild.focus();
                 e.preventDefault();
+              }
+              else if (target.parentElement && input === '') {
+                var previousSibling = target.parentElement.previousSibling;
+
+                if (previousSibling) {
+                  var lastChildOfParent = previousSibling.lastElementChild;
+                  if (lastChildOfParent) {
+                    lastChildOfParent.focus();
+                    e.preventDefault();
+                  }
+                }
               }
             }
           }

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -42,7 +42,7 @@ export function Word(props, ...children) {
                 prevChild.focus();
                 e.preventDefault();
               } else if (target != null && target.parentElement && input === '') {
-                const {previousSibling} = target.parentElement.previousSibling;
+                const { previousSibling } = target.parentElement.previousSibling;
                 if (previousSibling !== null) {
                   const lastChildOfParent = previousSibling.lastElementChild;
                   if (lastChildOfParent) {

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -41,10 +41,9 @@ export function Word(props, ...children) {
               if (prevChild !== null && input === '') {
                 prevChild.focus();
                 e.preventDefault();
-              }
-              else if (target.parentElement && input === '') {
+              }else if (target.parentElement && input === '') {
                 const previousSibling = target.parentElement.previousSibling;
-                if (previousSibling) {
+                if (previousSibling !== null) {
                   const lastChildOfParent = previousSibling.lastElementChild;
                   if (lastChildOfParent) {
                     lastChildOfParent.focus();

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -41,7 +41,7 @@ export function Word(props, ...children) {
               if (prevChild !== null && input === '') {
                 prevChild.focus();
                 e.preventDefault();
-              }else if (target.parentElement && input === '') {
+              }else if (target != null && target.parentElement && input === '') {
                 const previousSibling = target.parentElement.previousSibling;
                 if (previousSibling !== null) {
                   const lastChildOfParent = previousSibling.lastElementChild;

--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -42,7 +42,7 @@ export function Word(props, ...children) {
                 prevChild.focus();
                 e.preventDefault();
               } else if (target != null && target.parentElement && input === '') {
-                const previousSibling = target.parentElement.previousSibling;
+                const {previousSibling} = target.parentElement.previousSibling;
                 if (previousSibling !== null) {
                   const lastChildOfParent = previousSibling.lastElementChild;
                   if (lastChildOfParent) {

--- a/tests/components.spec.js
+++ b/tests/components.spec.js
@@ -101,7 +101,7 @@ describe('Tests for components', () => {
     it('jumps to the previous input field when pressing backspace in empty field', () => {
       const onInput = jest.fn();
       const props = { ...getMockState(), word: 'one', wordIndex: 0, charInput: onInput };
-      const root = document.createElement('div');
+      const root = document.createElement('div');  
       render(Word(props), root);
       const inputs = root.querySelectorAll('input');
       const mockEvent = new Event('keydown');
@@ -110,6 +110,24 @@ describe('Tests for components', () => {
       inputs[1].dispatchEvent(mockEvent);
       expect(inputs[0] === document.activeElement).toEqual(true);
     });
+
+    it('clears everything if you hold backspace', () => {
+      const onInput = jest.fn();
+      const props = { ...getMockState(), word: 'one word', wordIndex: 0, charInput: onInput };
+      const root = document.createElement('div');  
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.key = 'Backspace';
+      inputs[7].focus();
+      inputs[7].dispatchEvent(mockEvent);
+      inputs[6].dispatchEvent(mockEvent);
+      inputs[5].dispatchEvent(mockEvent);
+      inputs[4].dispatchEvent(mockEvent);
+      inputs[3].dispatchEvent(mockEvent);
+      expect(inputs[2] === document.activeElement).toEqual(true);
+    });
+
     it('remains on the same input field when pressing backspace in non empty field', () => {
       const onInput = jest.fn();
       const props = { ...getMockState(), word: 'one', wordIndex: 0, charInput: onInput };


### PR DESCRIPTION
Associated Issue: #263

Holding backspace will now clear up all the rows rather than one row.

The only change has been made to src/js/components/Word.js
