### PR TITLE
[PR] Words with non-letter characters buggy

### DIFF
--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -15,7 +15,7 @@ export function Word(props, ...children) {
             const input = e.target.value;
             charInput(input, props.wordIndex, charIndex);
 
-            if (/[a-zA-Z]/.test(input)) {
+            if (/[a-zA-Z\d '-]/.test(input)) {
               const nextChild = e.target.nextElementSibling;
               const hasNextWord = !!this.$element.nextSibling;
 


### PR DESCRIPTION
Improved regex to accept:
- Space
- Dash
- Digits
- Apostrophe

Associated Issue: #260

### Summary of Changes

- Changed Word.js regex from `[a-zA-Z]` to `[a-zA-Z\d '-]`
