### PR TITLE
Allow browsing the App by IP as well #375

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = publicPath => ({
   ],
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
-    port: 3000
+    port: 3000,
+    host: '0.0.0.0'
   }
 });


### PR DESCRIPTION
Associated Issue: #375 

### Summary of Changes

Added `host` option to webpack.config.js to allow browsing the app by IP on development machine