### PR TITLE
Added 12 new rebuses

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -887,6 +887,66 @@ const rebuses = [
     symbols: ['🍯', '+', '🐝'],
     words: ['honeybee'],
     hint: ['An insect that makes a sweet treat.']
+  },
+  {
+    symbols: ['🐝', '+', '🙋', '+', 'VE'],
+    words: ['beehive'],
+    hint: ['Home of a bee.']
+  },
+  {
+    symbols: ['👻', '+', '🏍️'],
+    words: ['ghostrider'],
+    hint: ['Famous Hollywood Movie']
+  },
+  {
+    symbols: ['🔴', '+', 'Z', '+', '1️⃣'],
+    words: ['redzone'],
+    hint: ['Danger Area']
+  },
+  {
+    symbols: ['🟩', '+', 'Z', '+', '1️⃣'],
+    words: ['greenzone'],
+    hint: ['Unrestricted Area']
+  },
+  {
+    symbols: ['🐵', '-', '🗝️', '+', '☀️'],
+    words: ['monday'],
+    hint: ['Comes after weekend']
+  },
+  {
+    symbols: ['🆓', '+', '🔫'],
+    words: ['freefire'],
+    hint: ['A competitor of pubg mobile']
+  },
+  {
+    symbols: ['🩸', '+', '🏦'],
+    words: ['bloodbank'],
+    hint: ['A major requirement for health sector']
+  },
+  {
+    symbols: ['🌽 ', '+', '🍞'],
+    words: ['cornbread'],
+    hint: ['An eatable']
+  },
+  {
+    symbols: ['🍔', '+', '👑'],
+    words: ['burgerking'],
+    hint: ['A kind of Burger']
+  },
+  {
+    symbols: ['❤️', '+', '✉️'],
+    words: ['loveletter'],
+    hint: ['For the lovers']
+  },
+  {
+    symbols: ['🐴', '+', '💪'],
+    words: ['horsepower'],
+    hint: ['A unit of power']
+  },
+  {
+    symbols: ['☕', '+', '💔'],
+    words: ['coffeebreak'],
+    hint: ['Necessary between continuous work']
   }
 ];
 


### PR DESCRIPTION
Associated Issue: #121 

### Summary of Changes

Successfully added 12 new rebuses along with hints which will help in continuing this fun game.
Added rebuses are :
- BEEHIVE
- GHOSTRIDER
- MODAY
- RED ZONE
- FREEFIRE
- BLOODBANK
- CORNBREAD
- BURGERKING
- GREENZONE
- LOVELETTER
- HORSEPOWER
- COFFEEBREAK

Some snapshots:
![rebuses](https://user-images.githubusercontent.com/64154442/89122722-5497f480-d4e7-11ea-9ad4-fe32eb77a35e.JPG)
![rebus3](https://user-images.githubusercontent.com/64154442/89122724-5661b800-d4e7-11ea-8ffb-3bea56328fa8.JPG)
![rebus2](https://user-images.githubusercontent.com/64154442/89122726-5792e500-d4e7-11ea-905a-28b0349eb9bc.JPG)


