### PR TITLE
Adding a new rebus

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -887,6 +887,11 @@ const rebuses = [
     symbols: ['🍯', '+', '🐝'],
     words: ['honeybee'],
     hint: ['An insect that makes a sweet treat.']
+   },
+  {
+    symbols: ['🔥', '+', '🐜'],
+    words: ['Firebug'],
+    hint: ['Old tool to debBUG in Firefox web browser. Also a kind of bug']
   }
 ];
 


### PR DESCRIPTION
Adding a new rebus

    firebug        Old tool of firefox to debBUG, also a kind of bug.

###   I'd a couple of problems since I was editing the files in Windows, it was reported with lint that an LF was expected instead of CRLF, I found in a forum how to change the setting to expect CRLF instead of LF, also how to ignore and not verify the line-breaks, this second option since I still got 1 error (the first time I got more than 2000 errors). 

I decided to go forward since I tested, I played and everything seems to be ok (the test result said all test passed),  despite I still got an error when running prettier as follows

>npm run test:all

> npm run test && npm run lint


> rebus@1.0.0 test C:\Users\mick_\Documents\manolasco\git\rebus
> jest

 PASS  tests/mini.spec.js
 PASS  tests/store.spec.js
 PASS  tests/components.spec.js
 PASS  tests/app.spec.js

 PASS  tests/rebus.spec.js

Test Suites: 5 passed, 5 total
Tests:       47 passed, 47 total
Snapshots:   37 passed, 37 total
Time:        4.332s
Ran all test suites.

> rebus@1.0.0 lint C:\Users\mick_\Documents\manolasco\git\rebus
> eslint src tests

> rebus@1.0.0 lint C:\Users\mick_\Documents\manolasco\git\rebus
> eslint src tests


C:\Users\mick_\Documents\manolasco\git\rebus\src\js\rebuses.js
  890:3  error  Delete `·`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! rebus@1.0.0 lint: `eslint src tests`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the rebus@1.0.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\mick_\AppData\Roaming\npm-cache\_logs\2020-09-09T18_00_30_337Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! rebus@1.0.0 test:all: `npm run test && npm run lint`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the rebus@1.0.0 test:all script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\mick_\AppData\Roaming\npm-cache\_logs\2020-09-09T18_00_30_361Z-debug.log

## The contents of 2020-09-09T18_00_30_361Z-debug.log

0 info it worked if it ends with ok
1 verbose cli [
1 verbose cli   'C:\\Program Files\\nodejs\\node.exe',
1 verbose cli   'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
1 verbose cli   'run',
1 verbose cli   'test:all'
1 verbose cli ]
2 info using npm@6.14.5
3 info using node@v12.18.1
4 verbose run-script [ 'pretest:all', 'test:all', 'posttest:all' ]
5 info lifecycle rebus@1.0.0~pretest:all: rebus@1.0.0
6 info lifecycle rebus@1.0.0~test:all: rebus@1.0.0
7 verbose lifecycle rebus@1.0.0~test:all: unsafe-perm in lifecycle true
8 verbose lifecycle rebus@1.0.0~test:all: PATH: C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\node-gyp-bin;C:\Users\mick_\Documents\manolasco\git\rebus\node_modules\.bin;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0\;C:\windows\System32\OpenSSH\;C:\Program Files\nodejs\;C:\Program Files (x86)\QuickTime\QTSystem\;C:\Program Files\PuTTY\;C:\Program Files\Git\cmd;C:\Users\mick_\AppData\Local\Microsoft\WindowsApps;C:\Users\mick_\AppData\Roaming\npm;C:\Users\mick_\AppData\Local\atom\bin;C:\Program Files (x86)\Nmap
9 verbose lifecycle rebus@1.0.0~test:all: CWD: C:\Users\mick_\Documents\manolasco\git\rebus
10 silly lifecycle rebus@1.0.0~test:all: Args: [ '/d /s /c', 'npm run test && npm run lint' ]
11 silly lifecycle rebus@1.0.0~test:all: Returned: code: 1  signal: null
12 info lifecycle rebus@1.0.0~test:all: Failed to exec test:all script
13 verbose stack Error: rebus@1.0.0 test:all: `npm run test && npm run lint`
13 verbose stack Exit status 1
13 verbose stack     at EventEmitter.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\index.js:332:16)
13 verbose stack     at EventEmitter.emit (events.js:315:20)
13 verbose stack     at ChildProcess.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\lib\spawn.js:55:14)
13 verbose stack     at ChildProcess.emit (events.js:315:20)
13 verbose stack     at maybeClose (internal/child_process.js:1021:16)
13 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
14 verbose pkgid rebus@1.0.0
15 verbose cwd C:\Users\mick_\Documents\manolasco\git\rebus
16 verbose Windows_NT 10.0.18362
17 verbose argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "test:all"
18 verbose node v12.18.1
19 verbose npm  v6.14.5
20 error code ELIFECYCLE
21 error errno 1
22 error rebus@1.0.0 test:all: `npm run test && npm run lint`
22 error Exit status 1
23 error Failed at the rebus@1.0.0 test:all script.
23 error This is probably not a problem with npm. There is likely additional logging output above.
24 verbose exit [ 1, true ]



Associated Issue: #<issue number>

### Summary of Changes

- change 1
- change 2
