### PR TITLE
Backspace deletes the previous letter

### DIFF
--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -40,6 +40,7 @@ export function Word(props, ...children) {
               const prevChild = target.previousElementSibling;
               if (prevChild !== null && input === '') {
                 prevChild.focus();
+                prevChild.value = '';
                 e.preventDefault();
               }
             }


### PR DESCRIPTION
Associated Issue: #675 

### Summary of Changes

- change 1
Backspace now deletes the previous letter directly instead of just going back to the previous letter.
