### PR TITLE
Feat/issue#263 backspace deletes multi word rebus

### DIFF
--- a/src/js/components/Word.js
+++ b/src/js/components/Word.js
@@ -37,9 +37,18 @@ export function Word(props, ...children) {
             }
             if (key === 'Backspace' || keyCode === 8) {
               const input = target.value;
-              const prevChild = target.previousElementSibling;
+              let prevChild = target.previousElementSibling;
+              if (prevChild === null) {
+                const parent = target.parentElement;
+                const parentSibling = parent.previousElementSibling;
+                if (parentSibling === null) {
+                  return;
+                }
+                prevChild = parentSibling.lastElementChild;
+              }
               if (prevChild !== null && input === '') {
                 prevChild.focus();
+                prevChild.value = '';
                 e.preventDefault();
               }
             }

--- a/tests/components.spec.js
+++ b/tests/components.spec.js
@@ -123,6 +123,34 @@ describe('Tests for components', () => {
       inputs[1].dispatchEvent(mockEvent);
       expect(inputs[1] === document.activeElement).toEqual(true);
     });
+    it('clears all previous row input fields on holding backspace on the input field of current row', () => {
+      const onInput = jest.fn();
+      const props = {
+        ...getMockState(),
+        word: 'three different words',
+        wordIndex: 0,
+        charInput: onInput
+      };
+      const root = document.createElement('div');
+      render(Word(props), root);
+      const inputs = root.querySelectorAll('input');
+      const mockEvent = new Event('keydown');
+      mockEvent.key = 'Backspace';
+      inputs[17].focus();
+      inputs[16].dispatchEvent(mockEvent);
+      inputs[15].dispatchEvent(mockEvent);
+      inputs[14].dispatchEvent(mockEvent);
+      inputs[13].dispatchEvent(mockEvent);
+      inputs[12].dispatchEvent(mockEvent);
+      inputs[11].dispatchEvent(mockEvent);
+      inputs[10].dispatchEvent(mockEvent);
+      inputs[9].dispatchEvent(mockEvent);
+      inputs[8].dispatchEvent(mockEvent);
+      inputs[7].dispatchEvent(mockEvent);
+      inputs[6].dispatchEvent(mockEvent);
+      inputs[5].dispatchEvent(mockEvent);
+      expect(inputs[4] === document.activeElement).toEqual(true);
+    });
     it('clears field when user enters a valid letter character in non empty field', () => {
       const onInput = jest.fn();
       const props = { ...getMockState(), word: 'one', wordIndex: 0, charInput: onInput };


### PR DESCRIPTION
Associated Issue: #263

### Summary of Changes

Added the functionality that for a rebus with multiple words, holding the backspace key down deletes all letters until the start of the first word

- Holding backspace can now delete all the rows of input fields to delete any multi-word rebus as a whole.

- Added unit-tests to verify the newly added functionality that backspace deletes multi-word rebus (including many rows of input fields).
