### PR TITLE
check rebus answer before next one/ previous button stops at first rebus

### DIFF
--- a/src/js/store.js
+++ b/src/js/store.js
@@ -3,13 +3,35 @@ import { createStore } from './mini';
 import { getRebuses, markRebusAsAnswered } from './rebuses';
 
 export const actionsCreators = {
-  next: ({ current, rebuses }) => ({
-    current: current < rebuses.length - 1 ? current + 1 : 0,
-    animation: 'flip-vertical-right',
-    incorrectAnswerCount: 0
-  }),
+  next: ({ current, rebuses, incorrectAnswer, incorrectAnswerCount }) => {
+    const answeredRebuses = window.localStorage.getItem('answeredRebuses')
+    const singleRebus = JSON.parse(answeredRebuses).find(rebusId => rebusId === current + 1)
+    
+    if (singleRebus) { // if rebus ID already listed in answeredRebus, go to next one
+      return {
+        current: current < rebuses.length - 1 ? current + 1 : 0,
+        animation: 'flip-vertical-right',
+        incorrectAnswerCount: 0
+      }
+    } else { // if rebus ID is not listed in answeredRebus, check if answer correct before jump to next one
+      if (!incorrectAnswer) {
+        return {
+          current: current < rebuses.length - 1 ? current + 1 : 0,
+          animation: 'flip-vertical-right',
+          incorrectAnswerCount: 0,
+          incorrectAnswer: true
+        }
+      } else {
+        return {
+          current: current,
+          animation: 'shake',
+          incorrectAnswerCount: incorrectAnswerCount
+        }
+      }
+    }    
+  },
   prev: ({ current, rebuses }) => ({
-    current: current > 0 ? current - 1 : rebuses.length - 1,
+    current: current > 0 ? current - 1 : 0,
     animation: 'flip-vertical-left',
     incorrectAnswerCount: 0
   }),
@@ -28,7 +50,7 @@ export const actionsCreators = {
     updatedRebuses[current].input[index] = input;
     return { updatedRebuses };
   },
-  check: ({ current, rebuses, incorrectAnswerCount }, confettiCanon) => {
+  check: ({ current, rebuses, incorrectAnswer, incorrectAnswerCount }, confettiCanon) => {
     const rebus = rebuses[current];
     const input = rebus.input.join('').toUpperCase();
     const answer = rebus.words.join('').toUpperCase();
@@ -40,9 +62,9 @@ export const actionsCreators = {
       confetti(confettiCanon);
       const updatedRebuses = [...rebuses];
       updatedRebuses[current].isAnswered = true;
-      return { updatedRebuses, animation: 'none', incorrectAnswerCount: 0 };
+      return { updatedRebuses, animation: 'none', incorrectAnswer: true, incorrectAnswerCount: 0 };
     }
-    return { incorrectAnswerCount: incorrectAnswerCount + 1 };
+    return { incorrectAnswer: false, incorrectAnswerCount: incorrectAnswerCount + 1 };
   },
   shake: ({ current, rebuses }) => {
     const rebus = rebuses[current];
@@ -58,6 +80,7 @@ export const initialState = {
   current: 0,
   animation: 'none',
   rebuses: getRebuses(),
+  incorrectAnswer: true,
   incorrectAnswerCount: 0
 };
 


### PR DESCRIPTION
Associated Issue: #641 #226

### Summary of Changes

- As addressed in the issues list, now the forward button doesn't work until the current rebus is answered
- When you click on the prev button, you now go back to previous rebuses until the first one. You will not be able to reach the last rebus of the list
