### PR TITLE
unified data structure on rebuses

### DIFF
--- a/src/js/rebuses.js
+++ b/src/js/rebuses.js
@@ -2,57 +2,57 @@ const rebuses = [
   {
     symbols: ['Re', '+', '🚌'],
     words: ['Rebus'],
-    hint: 'You´re solving one right now'
+    hint: [`You're solving one right now`]
   },
   {
     symbols: ['🏠', '+', 'pl', '+', '🐜', '+', 's'],
     words: ['Houseplants'],
-    hint: `The second emoji is 'ant' not 'bug'`
+    hint: [`The second emoji is 'ant' not 'bug'`]
   },
   {
     symbols: ['📖', '+', '🙋', '+', '📝'],
     words: ['Readme', 'file'],
-    hint: 'The default markdown file of every GitHub repo'
+    hint: [`The default markdown file of every GitHub repo`]
   },
   {
     symbols: ['🚗', '+', 'a', '+', '🚐'],
     words: ['Caravan'],
-    hint: 'The trailer you take when you go camping'
+    hint: [`The trailer you take when you go camping`]
   },
   {
     symbols: ['⭐', '+', '🐠'],
     words: ['Starfish'],
-    hint: 'Say the two emojis out loud'
+    hint: [`Say the two emojis out loud`]
   },
   {
     symbols: ['💡', '+', '🏠'],
     words: ['Lighthouse'],
-    hint: 'A tower with a light to guide ships at sea'
+    hint: [`A tower with a light to guide ships at sea`]
   },
   {
     symbols: ['🌲', '+', '🍎'],
     words: ['Pineapple'],
-    hint: 'Who lives in a ____ under the sea? SPONGEBOB SQUAREPANTS!'
+    hint: [`Who lives in a ____ under the sea? SPONGEBOB SQUAREPANTS!`]
   },
   {
     symbols: ['🥚', '+', '🌱'],
     words: ['Eggplant'],
-    hint: '🍆'
+    hint: [`🍆`]
   },
   {
     symbols: ['🔥', '+', '🦊'],
     words: ['Firefox'],
-    hint: 'One of the most popular web browsers'
+    hint: [`One of the most popular web browsers`]
   },
   {
     symbols: ['💊', '+', 'ow'],
     words: ['Pillow'],
-    hint: 'Soft item to rest your head when you sleep'
+    hint: [`Soft item to rest your head when you sleep`]
   },
   {
     symbols: ['🖊️', '+', 'd', '+', '🐜'],
     words: ['Pendant'],
-    hint: `The second emoji is 'ant' not 'bug'`
+    hint: [`The second emoji is 'ant' not 'bug'`]
   },
   {
     symbols: ['🌡️', '+', '🔑'],
@@ -61,47 +61,47 @@ const rebuses = [
   {
     symbols: ['🌞', '+', '🛀'],
     words: ['Sunbath'],
-    hint: 'A way for cold-blooded animals to keep warm'
+    hint: [`A way for cold-blooded animals to keep warm`]
   },
   {
     symbols: ['🚗', '🚙', '🚗'],
     words: ['Cars'],
-    hint: `They're always on the road`
+    hint: [`They're always on the road`]
   },
   {
     symbols: ['👦🏻', '+', '⚡', '+', '👓', '=', '✨'],
     words: ['Harry', 'Potter'],
-    hint: 'Hogwarts'
+    hint: [`Hogwarts`]
   },
   {
     symbols: ['H', '=', 'C', '👒'],
     words: ['Cat'],
-    hint: `It's raining ____ and dogs`
+    hint: [`It's raining ____ and dogs`]
   },
   {
     symbols: ['FR', '=', 'D', '🐸'],
     words: ['Dog'],
-    hint: `Man's best friend`
+    hint: [`Man's best friend`]
   },
   {
     symbols: ['📦', 'B', '=', 'F'],
     words: ['Fox'],
-    hint: `Say the emoji out loud and replace the 'B' with 'F'`
+    hint: [`Say the emoji out loud and replace the 'B' with 'F'`]
   },
   {
     symbols: ['G', '+', '❤️'],
     words: ['Glove'],
-    hint: `It covers your hand when it's cold outside`
+    hint: [`It covers your hand when it's cold outside`]
   },
   {
     symbols: ['🍏', '-', '🐒', '+', '🐜'],
     words: ['Plant'],
-    hint: `It grows in your garden`
+    hint: [`It grows in your garden`]
   },
   {
     symbols: ['🐝', '🍁'],
     words: ['Belief'],
-    hint: `Hmm, there's a bee and a leaf. Say both out loud`
+    hint: [`Hmm, there's a bee and a leaf. Say both out loud`]
   },
   {
     symbols: ['🐱', '+', 'as', '+', '🏆', 'y̶', '+', 'e'],
@@ -111,187 +111,187 @@ const rebuses = [
   {
     symbols: ['🍑', '🍑', '+', 'i', 'n', 'a', 't', 'e'],
     words: ['Assassinate'],
-    hint: `What's another word for your butt? That's what the emojis mean`
+    hint: [`What's another word for your butt? That's what the emojis mean`]
   },
   {
     symbols: ['🍌', '+', '🍞'],
     words: ['Bananabread'],
-    hint: `A monkey's favourite bread`
+    hint: [`A monkey's favourite bread`]
   },
   {
     symbols: ['🔑', '🐗', '+', 'd'],
     words: ['Keyboard'],
-    hint: `You're typing with one`
+    hint: [`You're typing with one`]
   },
   {
     symbols: ['💵', '+', 'ew'],
     words: ['cashew'],
-    hint: 'A type of nut'
+    hint: [`A type of nut`]
   },
   {
     symbols: ['🤘🏻', '+', '⭐️'],
     words: ['rockstar'],
-    hint: 'Mick Jagger is a what?'
+    hint: [`Mick Jagger is a what?`]
   },
   {
     symbols: ['Tu', '+', '👄'],
     words: ['Tulip'],
-    hint: 'This popular flower blooms in Spring'
+    hint: [`This popular flower blooms in Spring`]
   },
   {
     symbols: ['🔥', '+', '🐶'],
     words: ['Hotdog'],
-    hint: 'A close relative of burgers'
+    hint: [`A close relative of burgers`]
   },
   {
     symbols: ['🌙', '+', '☀'],
     words: ['Moonshine'],
-    hint: `Illegal alcohol`
+    hint: [`Illegal alcohol`]
   },
   {
     symbols: ['💻', '+', '🌊'],
     words: ['Digital', 'Ocean'],
-    hint: 'Similar to AWS and Microsoft Azure'
+    hint: [`Similar to AWS and Microsoft Azure`]
   },
   {
     symbols: ['🔥', '+', '🌬️', '+', '🎈'],
     words: ['Hot', 'Air', 'Balloon'],
-    hint: `Explore the skys with this`
+    hint: [`Explore the skys with this`]
   },
   {
     symbols: ['💵', '+', '⚽'],
     words: ['Moneyball'],
-    hint: `A great baseball movie`
+    hint: [`A great baseball movie`]
   },
   {
     symbols: ['🐂', '+', '👀'],
     words: ['Bullseye'],
-    hint: 'The center/smallest part of a target'
+    hint: [`The center/smallest part of a target`]
   },
   {
     symbols: ['🦇', '+', 'tery'],
     words: ['Battery'],
-    hint: 'All your devices contain one'
+    hint: [`All your devices contain one`]
   },
   {
     symbols: ['🔒', '+', 'smith'],
     words: ['Locksmith'],
-    hint: 'This person lets you into your home when you lose your keys'
+    hint: [`This person lets you into your home when you lose your keys`]
   },
   {
     symbols: ['👞', '+', 'horn'],
     words: ['Shoehorn'],
-    hint: `Helps you put your shoe on`
+    hint: [`Helps you put your shoe on`]
   },
   {
     symbols: ['🖊', '+', 't', '+', '🏠'],
     words: ['Penthouse'],
-    hint: `The highest room in a hotel`
+    hint: [`The highest room in a hotel`]
   },
   {
     symbols: ['🐱', '+', 'e', '+', '💍'],
     words: ['Catering'],
-    hint: 'Spell out the emojis then pronounce the word'
+    hint: [`Spell out the emojis then pronounce the word`]
   },
   {
     symbols: ['2', '+', 'Na️', '+', '🐟'],
     words: ['tunafish'],
-    hint: 'A key ingredient in tuna salad'
+    hint: [`A key ingredient in tuna salad`]
   },
   {
     symbols: ['🔥', '+', 'man'],
     words: ['Fireman'],
-    hint: 'Helps put out large fires'
+    hint: [`Helps put out large fires`]
   },
   {
     symbols: ['💡', '+', 'er'],
     words: ['Lighter'],
-    hint: 'Used to ignite cigarettes'
+    hint: [`Used to ignite cigarettes`]
   },
   {
     symbols: ['🌙', '+', '💡'],
     words: ['Moonlight'],
-    hint: `Lights up the night`
+    hint: [`Lights up the night`]
   },
   {
     symbols: ['f', '+', '🌬️', '+', 'y'],
     words: ['Fairy'],
-    hint: 'The tooth ____ changes lost teeth to money'
+    hint: [`The tooth ____ changes lost teeth to money`]
   },
   {
     symbols: ['🔨', '+', '⏰'],
     words: ['Hammer', 'time'],
-    hint: `MC Hammer's popular one-liner`
+    hint: [`MC Hammer's popular one-liner`]
   },
   {
     symbols: ['👻', '+', '🚂'],
     words: ['Ghost', 'Train'],
-    hint: `A haunted train`
+    hint: [`A haunted train`]
   },
   {
     symbols: ['🍦', '+', '🍦', '+', '👶'],
     words: ['Ice', 'Ice', 'Baby'],
-    hint: `A great hit by Vanilla Ice`
+    hint: [`A great hit by Vanilla Ice`]
   },
   {
     symbols: ['🚗', '+', 'D', '+', '👹', '+', '🐏'],
     words: ['cardiogram'],
-    hint: `Graph showing your heart's activity over a period of time`
+    hint: [`Graph showing your heart's activity over a period of time`]
   },
   {
     symbols: ['🌎', '+', 'wide', '+', '🕸️'],
     words: ['world', 'wide', 'web'],
-    hint: `What does the 'www' in websites stand for?`
+    hint: [`What does the 'www' in websites stand for?`]
   },
   {
     symbols: ['🐀', '+', 'AT', '+', '2️', '+', 'E'],
     words: ['ratatouille'],
-    hint: 'A rat chef'
+    hint: [`A rat chef`]
   },
   {
     symbols: ['📖', '+', '🔑', '+', 'ping'],
     words: ['bookkeeping'],
-    hint: 'Maintaining financial records of a business'
+    hint: [`Maintaining financial records of a business`]
   },
   {
     symbols: ['sc', '+', '🦍', '+', '🐐'],
     words: ['scapegoat'],
-    hint: 'Just say it out loud'
+    hint: [`Just say it out loud`]
   },
   {
     symbols: ['🐜', '+', '⛵️', '+', 'tica'],
     words: ['antarctica'],
-    hint: 'The southernmost continent on the planet'
+    hint: [`The southernmost continent on the planet`]
   },
   {
     symbols: ['🌧', '+', '🏹'],
     words: ['rainbow'],
-    hint: 'You see this after it rains'
+    hint: [`You see this after it rains`]
   },
   {
     symbols: ['❄️', '+', '⚾️'],
     words: ['snowball'],
-    hint: `Throw them at your friends in winter`
+    hint: [`Throw them at your friends in winter`]
   },
   {
     symbols: ['❄️', '+', 'man'],
     words: ['snowman'],
-    hint: 'You make this when its snowing'
+    hint: [`You make this when its snowing`]
   },
   {
     symbols: ['🐏', '📃'],
     words: ['rampage'],
-    hint: `The Hulk likes to go on a ____`
+    hint: [`The Hulk likes to go on a ____`]
   },
   {
     symbols: ['🐈', '+', '🥊'],
     words: ['cat', 'fight'],
-    hint: 'AKA girl fight'
+    hint: [`AKA girl fight`]
   },
   {
     symbols: ['👣', '+', '📝'],
     words: ['footnote'],
-    hint: 'Placed at the bottom of a page to describe something referenced in the page'
+    hint: [`Placed at the bottom of a page to describe something referenced in the page`]
   },
   {
     symbols: ['🐝', '+', 'r'],
@@ -301,572 +301,574 @@ const rebuses = [
   {
     symbols: ['🎉', '-', 'Y', '+', '⏰', '+', 'Job'],
     words: ['part', 'time', 'job'],
-    hint: `If 🎉 means 'party', remove the 'y'`
+    hint: [`If 🎉 means 'party', remove the 'y'`]
   },
   {
     symbols: ['🌲', '+', '🏠'],
     words: ['treehouse'],
-    hint: 'A house built in a tree'
+    hint: [`A house built in a tree`]
   },
   {
     symbols: ['✔', '+', 'list'],
     words: ['checklist'],
-    hint: 'What you might use to keep track of your tasks for the day'
+    hint: [`What you might use to keep track of your tasks for the day`]
   },
   {
     symbols: ['💧', '+', '📦'],
     words: ['Dropbox'],
-    hint: 'A popular cloud storage company; say the emojis out loud'
+    hint: [`A popular cloud storage company; say the emojis out loud`]
   },
   {
     symbols: ['💡', '+', '⚔️'],
     words: ['Lightsaber'],
-    hint: 'The Star Wars weapon for hand-to-hand combat'
+    hint: [`The Star Wars weapon for hand-to-hand combat`]
   },
   {
     symbols: ['☕️'],
     words: ['Java'],
-    hint: 'A highly popular programming language owned by Oracle'
+    hint: [`A highly popular programming language owned by Oracle`]
   },
   {
     symbols: ['⎈'],
     words: ['Helm'],
-    hint: 'Where you steer the boat'
+    hint: [`Where you steer the boat`]
   },
   {
     symbols: ['🌍', '+', 'form'],
     words: ['Terraform'],
-    hint: `A code software HashiCorp`
+    hint: [`A code software HashiCorp`]
   },
   {
     symbols: ['Uni', '+', '🌽'],
     words: ['unicorn'],
-    hint: 'A billion-dollar startup company'
+    hint: [`A billion-dollar startup company`]
   },
   {
     symbols: ['🆘', '+', 'desk'],
     words: ['helpdesk'],
-    hint: `Where you go to find help`
+    hint: [`Where you go to find help`]
   },
   {
     symbols: ['🐱', '+', 'er', '+', '🗼'],
     words: ['caterpillar'],
-    hint: 'It chews on leaves and then grows into something pretty.'
+    hint: [`It chews on leaves and then grows into something pretty.`]
   },
   {
     symbols: ['🧢', '+', 'tain'],
     words: ['captain'],
-    hint: '_____ America 💪'
+    hint: [`_____ America 💪`]
   },
   {
     symbols: ['🦊', '+', 'hole'],
     words: ['foxhole'],
-    hint: `A multiplayer strategy action game`
+    hint: [`A multiplayer strategy action game`]
   },
   {
     symbols: ['🐦', '+', 's-', '+', '👁️'],
     words: ["bird's-eye"],
-    hint: `When you observe from above`
+    hint: [`When you observe from above`]
   },
   {
     symbols: ['🐴', '+', '🔙'],
     words: ['horseback'],
-    hint: `A cowboy's primary form of travel`
+    hint: [`A cowboy's primary form of travel`]
   },
   {
     symbols: ['🎼', '+', '🍴'],
     words: ['pitchfork'],
-    hint: `Angry mobs are frequently seen with this`
+    hint: [`Angry mobs are frequently seen with this`]
   },
   {
     symbols: ['🌊', '+', '🐴'],
     words: ['seahorse'],
-    hint: `One of Nemo's friends was a _______`
+    hint: [`One of Nemo's friends was a _______`]
   },
   {
     symbols: ['🔙', '+', '💀'],
     words: ['backbone'],
-    hint: 'Another name for your spine'
+    hint: [`Another name for your spine`]
   },
   {
     symbols: ['💥', '+', '🌽'],
     words: ['popcorn'],
-    hint: 'You watch movies with ___ and a drink'
+    hint: [`You watch movies with ___ and a drink`]
   },
   {
     symbols: ['🔥', '+', '🏠'],
     words: ['firehouse'],
-    hint: `A very hot house`
+    hint: [`A very hot house`]
   },
   {
     symbols: ['🚗', '+', 'go'],
     words: ['cargo'],
-    hint: 'Items carried by ships and planes'
+    hint: [`Items carried by ships and planes`]
   },
   {
     symbols: ['sm', '+', '🎨'],
     words: ['smart'],
-    hint: `A synonym for 'intelligent'`
+    hint: [`A synonym for 'intelligent'`]
   },
   {
     symbols: ['😢', '+', '👶'],
     words: ['crybaby'],
-    hint: 'Someone who complains a lot'
+    hint: [`Someone who complains a lot`]
   },
   {
     symbols: ['📻', '+', '🙂'],
     words: ['radiohead'],
-    hint: `An old English rock band`
+    hint: [`An old English rock band`]
   },
   {
     symbols: ['🗃', '+', 'elder', '+', '🐜'],
     words: ['Box', 'Elder', 'Bug'],
-    hint: `An annoying species of true bug`
+    hint: [`An annoying species of true bug`]
   },
   {
     symbols: ['L', '+', '🏹'],
     words: ['Elbow'],
-    hint: 'The joint in your arm below your shoulder'
+    hint: [`The joint in your arm below your shoulder`]
   },
   {
     symbols: ['📅', '+', 'et', '+', '🌍'],
     words: ['Planet', 'Earth'],
-    hint: `Where we all live`
+    hint: [`Where we all live`]
   },
   {
     symbols: ['🔨', '+', 'head', '+', '🦈'],
     words: ['hammerhead', 'shark'],
-    hint: 'A type of shark'
+    hint: [`A type of shark`]
   },
   {
     symbols: ['👩‍', '+', '💍'],
     words: ['red', 'herring'],
-    hint: `A tasty seafood meal`
+    hint: [`A tasty seafood meal`]
   },
   {
     symbols: ['Black', '+', '🎩'],
     words: ['Blackhat'],
-    hint: 'A type of hacker'
+    hint: [`A type of hacker`]
   },
   {
     symbols: ['👁', '+', '💧'],
     words: ['Eyedrop'],
-    hint: 'Used to treat irritated/inflammed eyes'
+    hint: [`Used to treat irritated/inflammed eyes`]
   },
   {
     symbols: ['🧠', '+', '🌪', '+', 'ing'],
     words: ['Brainstorming'],
-    hint: 'Thinking about ideas'
+    hint: [`Thinking about ideas`]
   },
   {
     symbols: ['👞', '+', '📦'],
     words: ['Shoebox'],
-    hint: 'A box you get shoes in'
+    hint: [`A box you get shoes in`]
   },
   {
     symbols: ['💵', '+', '🛍️'],
     words: ['Money', 'Bag'],
-    hint: `Every robbers desire`
+    hint: [`Every robbers desire`]
   },
   {
     symbols: ['💥', '+', 'py'],
     words: ['Poppy'],
-    hint: `They make opium from this`
+    hint: [`They make opium from this`]
   },
   {
     symbols: ['🍏', '+', '🥧'],
     words: ['Applepie'],
-    hint: `It's as American as ______`
+    hint: [`It's as American as ______`]
   },
   {
     symbols: ['🍯', '+', '🌗'],
     words: ['Honeymoon'],
-    hint: 'Comes right after a wedding'
+    hint: [`Comes right after a wedding`]
   },
   {
     symbols: ['🕷', '+', '🧔🏻'],
     words: ['Spiderman'],
-    hint: `Uncle Ben's superhero nephew`
+    hint: [`Uncle Ben's superhero nephew`]
   },
   {
     symbols: ['🐲', '+', '🍑'],
     words: ['Dragonfruit'],
-    hint: `A mythical fruit made reality`
+    hint: [`A mythical fruit made reality`]
   },
   {
     symbols: ['🔫-s', '+', 'and', '+', '🥀-s'],
     words: ['Gunsandroses'],
-    hint: 'A popular rock band'
+    hint: [`A popular rock band`]
   },
   {
     symbols: ['👦🏼', '+', '📔'],
     words: ['Facebook'],
-    hint: `Mark Zuckerberg's company`
+    hint: [`Mark Zuckerberg's company`]
   },
   {
     symbols: ['T', '+', '🏃', '+', '🐱', '+', 'e'],
     words: ['Truncate'],
-    hint: 'To make something shorter by cutting off the end'
+    hint: [`To make something shorter by cutting off the end`]
   },
   {
     symbols: ['🐶', '+', '🐱', '+', 'cher'],
     words: ['Dogcatcher'],
-    hint: `In case your dog runs away`
+    hint: [`In case your dog runs away`]
   },
   {
     symbols: ['🌍', '+', '⭐️'],
     words: ['Earthstar'],
-    hint: `A star shaped fungi`
+    hint: [`A star shaped fungi`]
   },
   {
     symbols: ['👱', '+', '👨‍🎓', '+', '⛵️-s'],
     words: ['Headmasterships'],
-    hint: `The role of the headmaster`
+    hint: [`The role of the headmaster`]
   },
   {
     symbols: ['🅰️', '+', '💣', '+', 'in', '+', '🅰️', '+', '🐂'],
     words: ['Abominable'],
-    hint: 'The ___ Snowman'
+    hint: [`The ___ Snowman`]
   },
   {
     symbols: ['👁', '+', '💖', '+', 'YOU'],
     words: ['I', 'Love', 'You'],
-    hint: '3 words, 8 letters'
+    hint: [`3 words, 8 letters`]
   },
   {
     symbols: ['🐴', '+', '👞'],
     words: ['Horse', 'Shoe'],
-    hint: 'Read the emojis out loud'
+    hint: [`Read the emojis out loud`]
   },
   {
     symbols: ['🌍', '+', '☕'],
     words: ['World', 'Cup'],
-    hint: 'A football/soccer tournament played every 4 years and organized by FIFA'
+    hint: [`A football/soccer tournament played every 4 years and organized by FIFA`]
   },
   {
     symbols: ['🔁', '+', '🔙'],
     words: ['Loopback'],
-    hint: `Another word for rewind`
+    hint: [`Another word for rewind`]
   },
   {
     symbols: ['🔙', '+', '🏁'],
     words: ['Backend'],
-    hint: `The opposite of frontend`
+    hint: [`The opposite of frontend`]
   },
   {
     symbols: ['🌃', '+', '🐎'],
     words: ['Nightmare'],
-    hint: 'A bad dream'
+    hint: [`A bad dream`]
   },
   {
     symbols: ['🔙', '+', '🚪'],
     words: ['Backdoor'],
-    hint: `When the front door doesn't work`
+    hint: [`When the front door doesn't work`]
   },
   {
     symbols: ['🍀', '+', '🌌‍', '+', '🚶'],
     words: ['Luke Skywalker'],
-    hint: 'Star Wars: the other Skywalker (not Anakin)'
+    hint: [`Star Wars: the other Skywalker (not Anakin)`]
   },
   {
     symbols: ['👋', '+', '🌍'],
     words: ['Hello', 'World'],
-    hint: 'The popular output of many introductory computer programming tutorials'
+    hint: [`The popular output of many introductory computer programming tutorials`]
   },
   {
     symbols: ['🌽', '+', 'u', '+', '👮', '+', 'ia'],
     words: ['Cornucopia'],
-    hint: 'The horn of plenty'
+    hint: [`The horn of plenty`]
   },
   {
     symbols: ['💨', '+', '🦉', '-', 'L'],
     words: ['window'],
-    hint: `The competitor of Apple, without the 's' at the end`
+    hint: [`The competitor of Apple, without the 's' at the end`]
   },
   {
     symbols: ['❌', '+', '🔤'],
     words: ['crossword'],
-    hint: 'A type of puzzle'
+    hint: [`A type of puzzle`]
   },
   {
     symbols: ['S', '+', '🦀', '+', 'BLE'],
     words: ['scrabble'],
-    hint: 'Words With Friends is based on this game'
+    hint: [`Words With Friends is based on this game`]
   },
   {
     symbols: ['🦇', '+', '👨'],
     words: ['Batman'],
-    hint: 'Bruce Wayne'
+    hint: [`Bruce Wayne`]
   },
   {
     symbols: ['☀️', '+', '👓'],
     words: ['Sunglasses'],
-    hint: 'Prevents you from squinting all day at the beach'
+    hint: [`Prevents you from squinting all day at the beach`]
   },
   {
     symbols: ['🐄', '+', '👦'],
     words: ['Cowboy'],
-    hint: 'Heroes of the wild west'
+    hint: [`Heroes of the wild west`]
   },
   {
     symbols: ['🖊️', '+', '👬'],
     words: ['Penpals'],
-    hint: 'Friends who write letters to themselves'
+    hint: [`Friends who write letters to themselves`]
   },
   {
     symbols: ['⭐', '+', '💰'],
     words: ['Starbucks'],
-    hint: 'A popular American coffee company based in Seattle, Washington'
+    hint: [`A popular American coffee company based in Seattle, Washington`]
   },
   {
     symbols: ['📲', '+', '🅰️', '+', '🐀'],
     words: ['Apparat'],
-    hint: `A german electronic musician`
+    hint: [`A german electronic musician`]
   },
   {
     symbols: ['☀️', '+', '🌼'],
     words: ['Sunflower'],
-    hint: `A plant that always faces the sun`
+    hint: [`A plant that always faces the sun`]
   },
   {
     symbols: ['⛓️', '+', '🔁', '+', '🎬'],
     words: ['Chainreaction'],
-    hint: 'A series of events triggering each other'
+    hint: [`A series of events triggering each other`]
   },
   {
     symbols: ['🗑️', '+', '🏀'],
     words: ['Basketball'],
-    hint: `Michael Jordan's primary sport`
+    hint: [`Michael Jordan's primary sport`]
   },
   {
     symbols: ['🌎', '+', '🐛'],
     words: ['Earthworm'],
-    hint: `It's not a moonworm`
+    hint: [`It's not a moonworm`]
   },
   {
     symbols: ['🌬', '+', '🐟'],
     words: ['Blowfish'],
-    hint: `A fish that swells up`
+    hint: [`A fish that swells up`]
   },
   {
     symbols: ['🔑', '+', '🕳'],
     words: ['Keyhole'],
-    hint: 'Your house key goes into the ______'
+    hint: [`Your house key goes into the ______`]
   },
   {
     symbols: ['💔', '+', '🕐'],
     words: ['Breaktime'],
-    hint: `Everyone's favourite part of the day`
+    hint: [`Everyone's favourite part of the day`]
   },
   {
     symbols: ['🐊', '+', '😭'],
     words: ['Crocodile', 'tears'],
-    hint: `Fake tears`
+    hint: [`Fake tears`]
   },
   {
     symbols: ['💋', '☠'],
     words: ['Kiss', 'of', 'death'],
-    hint: `One kiss you don't want to receive`
+    hint: [`One kiss you don't want to receive`]
   },
   {
     symbols: ['👨', '💀', '⛵'],
     words: ['Pirate'],
-    hint: 'Criminals who ransacked ships in the 1700s-1900s'
+    hint: [`Criminals who ransacked ships in the 1700s-1900s`]
   },
   {
     symbols: ['🚪', '+', '🔔'],
     words: ['Doorbell'],
-    hint: `Used to alert the occupant's of a house that somebody is at their door`
+    hint: [`Used to alert the occupant's of a house that somebody is at their door`]
   },
   {
     symbols: ['🌙', '+', '🎂'],
     words: ['Mooncake'],
-    hint: `A lunar Chinese snack`
+    hint: [`A lunar Chinese snack`]
   },
   {
     symbols: ['🐎', '+', '👟'],
     words: ['Horseshoe'],
-    hint: `Protect's a horse's hooves`
+    hint: [`Protect's a horse's hooves`]
   },
   {
     symbols: ['⌚', '+', '👨'],
     words: ['Watchman'],
-    hint: 'Who watches the ______?'
+    hint: [`Who watches the ______?`]
   },
   {
     symbols: ['✋', '+', '📗'],
     words: ['Handbook'],
-    hint: 'An instructional manual'
+    hint: [`An instructional manual`]
   },
   {
     symbols: ['🛤️', '+', 'men'],
     words: ['Railwayman'],
-    hint: `Works in a railway yard`
+    hint: [`Works in a railway yard`]
   },
   {
     symbols: ['🐱', '+', '🐠'],
     words: ['Catfish'],
-    hint: 'A person who fakes his/her identity online'
+    hint: [`A person who fakes his/her identity online`]
   },
   {
     symbols: ['👂', '+', '💍'],
     words: ['Earring'],
-    hint: 'Say the emojis out loud'
+    hint: [`Say the emojis out loud`]
   },
   {
     symbols: ['10', '+', '🐜'],
     words: ['Tenant'],
-    hint: 'A person renting out an apartment'
+    hint: [`A person renting out an apartment`]
   },
   {
     symbols: ['⛵️', '+', 'ment'],
     words: ['Shipment'],
-    hint: `A package being delivered`
+    hint: [`A package being delivered`]
   },
   {
     symbols: ['2', '+', '🐝', '+', 'or', '+', 'not', '+', '2', '+', '🐝'],
     words: ['To Be Or Not To Be'],
-    hint: `A famous quote from Hamlet`
+    hint: [`A famous quote from Hamlet`]
   },
   {
     symbols: ['⬇', '➡', '+', '🤮'],
     words: ['downright disgusting'],
-    hint: `Something extremely displeasing`
+    hint: [`Something extremely displeasing`]
   },
   {
     symbols: ['🔥', '+', '🤼', '+', 'er'],
     words: ['firefighter'],
-    hint: 'They show up when there is a fire'
+    hint: [`They show up when there is a fire`]
   },
   {
     symbols: ['1', '+', 'ce', '+', 'n', '+', 'a', '+', '🔵', '+', '🌛'],
     words: ['Once', 'in', 'a', 'Blue Moon'],
-    hint: 'Phrase used when something only happens once in a while'
+    hint: [`Phrase used when something only happens once in a while`]
   },
   {
     symbols: ['🐱', '+', '🌲'],
     words: ['catalog'],
-    hint: `The Sear's ________`
+    hint: [`The Sear's ________`]
   },
   {
     symbols: ['💋', '+', 'able'],
     words: ['kissable'],
-    hint: `cute animals are very _____`
+    hint: [`cute animals are very _____`]
   },
   {
     symbols: ['😄', '+', '🎂🎁'],
     words: ['Happy', 'Birthday'],
-    hint: '____ to you!'
+    hint: [`____ to you!`]
   },
   {
     symbols: ['🔥', '+', '⚽'],
     words: ['Fireball'],
-    hint: 'The sun is a big ________'
+    hint: [`The sun is a big ________`]
   },
   {
     symbols: ['💎', '+', '⃝'],
     words: ['Diamond', 'ring'],
-    hint: ['Things you exchange in weddings.']
+    hint: [`Things you exchange in weddings.`]
   },
   {
     symbols: ['Black', '+', '🕳'],
     words: ['Black', 'hole'],
-    hint: ['Final form of a star.']
+    hint: [`Final form of a star.`]
   },
   {
     symbols: ['🐼', '-', 'DA', '+', '🍰'],
     words: ['Pancake'],
-    hint: 'A delicious breakfast'
+    hint: [`A delicious breakfast`]
   },
   {
     symbols: ['✝', '+', '🏹'],
     words: ['Crossbow'],
-    hint: 'What an unskilled archer would use'
+    hint: [`What an unskilled archer would use`]
   },
   {
     symbols: ['D', '+', '💡'],
     words: ['delight'],
-    hint: 'To please someone'
+    hint: [`To please someone`]
   },
   {
     symbols: ['🌲', '+', 'T'],
     words: ['treaty'],
-    hint: 'an agreement between countries'
+    hint: [`an agreement between countries`]
   },
   {
     symbols: ['👹', '+', '🚚'],
     words: ['monster', 'truck'],
-    hint: 'they have gigantic wheels!'
+    hint: [`they have gigantic wheels!`]
   },
   {
     symbols: ['🔑', '+', '⛓️'],
     words: ['keychain'],
-    hint: 'Something that holds on to one or more keys'
+    hint: [`Something that holds on to one or more keys`]
   },
   {
     symbols: ['💁', '+', '🖌'],
     words: ['hairbrush'],
-    hint: 'Tidy your hair with'
+    hint: [`Tidy your hair with`]
   },
   {
     symbols: ['💻'],
     words: ['laptop'],
-    hint: 'A portable computer'
+    hint: [`A portable computer`]
   },
   {
     symbols: ['⚠', '⬇', '🔋'],
     words: ['low', 'battery'],
-    hint: 'You need to charge your device soon'
+    hint: [`You need to charge your device soon`]
   },
   {
     symbols: ['📰'],
     words: ['newspaper'],
-    hint: 'Reading today&#39s ______'
+    hint: [`Reading today&#39s ______`]
   },
   {
     symbols: ['✉'],
     words: ['mail'],
-    hint: '"You&#39ve got ____"'
+    hint: [`"You&#39ve got ____"`]
   },
   {
     symbols: ['🌮', '+', '🥗'],
     words: ['taco', 'salad'],
-    hint: 'One food made up of the other food'
+    hint: [`One food made up of the other food`]
   },
   {
     symbols: ['🍇', '-', '(🐒🐒🐒)', '+', '🐜'],
     words: ['grant'],
-    hint: 'Break it up. Do the subtraction then add the addition to the end'
+    hint: [`Break it up. Do the subtraction then add the addition to the end`]
   },
   {
     symbols: ['👁', '+', '📱'],
     words: ['iPhone'],
-    hint: 'Steve Jobs'
+    hint: [`Steve Jobs`]
   },
   {
     symbols: ['→', '🦁', '👑'],
     words: ['the', 'lion', 'king'],
-    hint: `Classic 90's coming of age film about a lion who must re-take his father's throne and become king of the jungle`
+    hint: [
+      `Classic 90's coming of age film about a lion who must re-take his father's throne and become king of the jungle`
+    ]
   },
   {
     symbols: ['🚐', '+', 'Gogh'],
     words: ['van', 'Gogh'],
-    hint: 'Famous Dutch painter.'
+    hint: [`Famous Dutch painter.`]
   },
   {
     symbols: ['🖖'],
     words: ['Star', 'Trek'],
-    hint: 'Famous salute from what TV show?'
+    hint: [`Famous salute from what TV show?`]
   },
   {
     symbols: ['🎁', '+', '🃏'],
     words: ['gift', 'card'],
-    hint: 'You get one on your birthday'
+    hint: [`You get one on your birthday`]
   },
   {
     symbols: ['🏹', '+', '👔'],
     words: ['bow', 'tie'],
-    hint: ['An accessory that is often worn with a suit']
+    hint: [`An accessory that is often worn with a suit`]
   },
   {
     symbols: ['🔎', '+', '🎉'],
@@ -876,32 +878,32 @@ const rebuses = [
   {
     symbols: ['🐛', '+', '🕳'],
     words: ['worm', 'hole'],
-    hint: 'A passage through space creating a shortcut through time and space'
+    hint: [`A passage through space creating a shortcut through time and space`]
   },
   {
     symbols: ['🌎', 'OF', '⚔', 'CRAFT'],
     words: ['World', 'of', 'Warcraft'],
-    hint: ['Famous Blizzard online game']
+    hint: [`Famous Blizzard online game`]
   },
   {
     symbols: ['🍯', '+', '🐝'],
     words: ['honeybee'],
-    hint: ['An insect that makes a sweet treat.']
+    hint: [`An insect that makes a sweet treat.`]
   },
   {
     symbols: ['🧶'],
     words: ['yarn'],
-    hint: ['A package manager similar to NPM']
+    hint: [`A package manager similar to NPM`]
   },
   {
     symbols: ['☕️', '+', '📄'],
     words: ['java', 'script'],
-    hint: ['It makes the website interactive']
+    hint: [`It makes the website interactive`]
   },
   {
     symbols: ['🦀', '+', '🎂'],
     words: ['crab', 'cake'],
-    hint: 'A delicious appetizer'
+    hint: [`A delicious appetizer`]
   }
 ];
 


### PR DESCRIPTION
Associated Issue: none

### Summary of Changes

- Unified the data structure of rebuses: all rebus fields are now arrays of string, hints are strings with backticks to allow for quotes.

### Reasoning

Rebuses were all over the place with their hints. Some used single quote strings, some used backticked strings, some used array of string, formatted with either. I've opted to make all hints arrays of backticked strings, so that all three fields of a rebus look the same in terms of data type expected (array of string). Hints should imo be backticked to allow for quotes and correct grammar inside.
This change doesn't break anything, all tests passed successfully and only rebuses.js was touched.