### PR TITLE
Removed Atom Text Editor Link as atom is shuted down

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ To avoid this problem in the future, you can change your editor to use an end of
 - [GitHub Endorsed Beginning Contributer Repos](https://github.com/showcases/great-for-new-contributors)
 - [Sourcetree - Git GUI for macOS and Windows](https://www.sourcetreeapp.com/)
 - [VS Code - extensible code editor](https://code.visualstudio.com/)
-- [GitHub Atom - Hackable Text Editor for the 21st Century](https://atom.io/)
+
 
 ## Support
 


### PR DESCRIPTION
Associated Issue: #<issue number>

### Summary of Changes
Removed the link of atom text editor as it is shutdown
- change 1
- change 2
