### PR TITLE
style git-hub-corner img

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -202,6 +202,10 @@ progress[value]::-webkit-progress-value {
 .github-corner:hover .octo-arm {
   animation: octocat-wave 560ms ease-in-out;
 }
+.github-corner:hover{
+  color: black;
+  fill: white;
+}
 
 @keyframes octocat-wave {
   0%,


### PR DESCRIPTION
Associated Issue: #<issue number>

### Summary of Changes
styling the git-hub-corner image
- change 1
- change 2
![chrome_mocI5vkjc6](https://user-images.githubusercontent.com/94105514/211193090-cdc09d01-626b-4023-a23c-55319efa6e4c.png)
![chrome_ZceZ3valH6](https://user-images.githubusercontent.com/94105514/211193089-8ade2d77-9f1a-4914-b0ab-235a10c83180.png)
